### PR TITLE
Change logging of blockUnlocker.js to show users shares and total shares

### DIFF
--- a/lib/blockUnlocker.js
+++ b/lib/blockUnlocker.js
@@ -180,7 +180,8 @@ function runInterval(){
                         var percent = block.workerShares[worker] / totalShares;
                         var workerReward = Math.round(reward * percent);
                         payments[worker] = (payments[worker] || 0) + workerReward;
-                        log('info', logSystem, 'Block %d payment to %s for %d shares: %d', [block.height, worker, totalShares, payments[worker]]);
+                        //log('info', logSystem, 'Block %d payment to %s for %d shares: %d', [block.height, worker, totalShares, payments[worker]]);
+                        log('info', logSystem, 'Block %d payment to %s for %d shares out of %d total shares: %d', [block.height, worker, block.workerShares[worker], totalShares, payments[worker]]);
                     });
                 }
             });


### PR DESCRIPTION
The original wording made it seem like all users submitted the same amount of shares. This wording says how many shares a user submitted and the total number of shares. Example is below:

```
2018-01-23 22:10:47 Block 266608 payment to LqBdkPBg8NdUHDHb4fP4Qc8LfYCdCfVavgrsy5GhvaQZSLt43ctVr2YJSZ3cL469T7jMicE821Pv9ZyYCYjSAyX5Mc6AnwS for 131538385 shares out of 137588385 total shares: 808132110
2018-01-23 22:10:47 Block 266608 payment to LpXz7S1aaXQSudfsLDwY6ZANcD53BGq6iBccAsAaWSQvNED8LCSrrPUJAEWQX5avhSDWRTcVjWXir2TpexvFJU1z9ni5WrC for 6050000 shares out of 137588385 total shares: 37169373

```